### PR TITLE
Add financial manager role with RM permissions

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -14,7 +14,7 @@ const getLeads = async (req, res) => {
   try {
     let result;
 
-    if (role === 'relationship_mgr') {
+    if (role === 'relationship_mgr' || role === 'financial_manager') {
       result = await pool.query(
         `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role
          FROM leads l
@@ -47,7 +47,7 @@ const getLeads = async (req, res) => {
         `SELECT l.*, u.display_name AS assigned_user_name, u.role AS assigned_user_role
          FROM leads l
          LEFT JOIN users u ON l.assigned_to = u.id
-         WHERE u.role = 'relationship_mgr'
+         WHERE u.role = ANY('{relationship_mgr,financial_manager}')
          ORDER BY l.date DESC`
       );
     } else {
@@ -97,13 +97,13 @@ const addLead = async (req, res) => {
     let assignedTo = null;
     let finalTeamId = team_id;
 
-    if (role === 'relationship_mgr') {
-      assignedTo = user_id;
-      if (!finalTeamId) {
-        const rm = await pool.query('SELECT team_id FROM users WHERE id = $1', [user_id]);
-        finalTeamId = rm.rows[0]?.team_id || null;
-      }
+  if (role === 'relationship_mgr' || role === 'financial_manager') {
+    assignedTo = user_id;
+    if (!finalTeamId) {
+      const rm = await pool.query('SELECT team_id FROM users WHERE id = $1', [user_id]);
+      finalTeamId = rm.rows[0]?.team_id || null;
     }
+  }
 
     const safeTeamId = finalTeamId && finalTeamId.trim() !== '' ? finalTeamId : null;
     const safeAssignedTo = assignedTo && assignedTo.trim() !== '' ? assignedTo : null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
         <Route
           path="leads"
           element={
-            <ProtectedRoute allowedRoles={['super_admin', 'admin', 'team_leader', 'relationship_mgr']}>
+            <ProtectedRoute allowedRoles={['super_admin', 'admin', 'team_leader', 'relationship_mgr', 'financial_manager']}>
               <LeadsPage />
             </ProtectedRoute>
           }
@@ -86,7 +86,7 @@ function App() {
         <Route
           path="clients"
           element={
-            <ProtectedRoute allowedRoles={['super_admin', 'admin', 'team_leader', 'relationship_mgr']}>
+            <ProtectedRoute allowedRoles={['super_admin', 'admin', 'team_leader', 'relationship_mgr', 'financial_manager']}>
               <ClientsPage />
             </ProtectedRoute>
           }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,7 +37,7 @@ function Sidebar() {
       label: 'Leads',
       path: '/leads',
       icon: <Target size={18} className="mr-2" />,
-      roles: ['super_admin', 'admin', 'team_leader', 'relationship_mgr'],
+      roles: ['super_admin', 'admin', 'team_leader', 'relationship_mgr', 'financial_manager'],
     },
     {
       label: 'Teams',
@@ -56,7 +56,7 @@ function Sidebar() {
       label: 'Clients',
       path: '/clients',
       icon: <Trophy size={18} className="mr-2" />,
-      roles: ['super_admin', 'admin', 'team_leader', 'relationship_mgr'],
+      roles: ['super_admin', 'admin', 'team_leader', 'relationship_mgr', 'financial_manager'],
     },
   ];
 

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -90,7 +90,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
       status: formData.status as Lead['status'],
     };
 
-    if (role === 'relationship_mgr') {
+    if (role === 'relationship_mgr' || role === 'financial_manager') {
       const user = users.find(u => u.id === userId);
       if (user) {
         finalData = {

--- a/src/components/modals/UserModal.tsx
+++ b/src/components/modals/UserModal.tsx
@@ -150,6 +150,7 @@ const UserModal: React.FC<UserModalProps> = ({ isOpen, onClose, user }) => {
             <option value="admin">Admin</option>
             <option value="team_leader">Team Leader</option>
             <option value="relationship_mgr">Relationship Manager</option>
+            <option value="financial_manager">Financial Manager</option>
           </select>
         </div>
 

--- a/src/pages/Clientpage.tsx
+++ b/src/pages/Clientpage.tsx
@@ -17,7 +17,7 @@ const ClientsPage = () => {
 
   const wonLeads = leads.filter((lead) => {
     if (lead.status !== 'Won') return false;
-    if (role === 'relationship_mgr') {
+    if (role === 'relationship_mgr' || role === 'financial_manager') {
       return lead.assigned_to === userId;
     }
     return true;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -63,7 +63,11 @@ const Dashboard = () => {
     }));
 
   const rmSales = users
-    .filter(u => u.role === 'relationship_mgr' && (role !== 'team_leader' || u.team_id === teamId))
+    .filter(
+      u =>
+        (u.role === 'relationship_mgr' || u.role === 'financial_manager') &&
+        (role !== 'team_leader' || u.team_id === teamId)
+    )
     .map(rm => {
       const rmLeads = filteredLeads.filter(l => l.assigned_to === rm.id && l.status === 'Won');
       const sales = rmLeads.reduce((sum, lead) => {

--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -155,7 +155,11 @@ function LeadsPage() {
   const filteredLeads = leads.filter((lead) => {
   // Hide leads that have been converted to clients
   if (lead.status === 'Won') return false;
-  if (role === 'relationship_mgr' && lead.assigned_to !== userId) return false;
+  if (
+    (role === 'relationship_mgr' || role === 'financial_manager') &&
+    lead.assigned_to !== userId
+  )
+    return false;
   if (role === 'team_leader' && lead.team_id !== users.find(u => u.id === userId)?.team_id) return false;
   if (statusFilter === 'assigned' && !lead.assigned_to) return false;
   if (statusFilter === 'unassigned' && lead.assigned_to) return false;
@@ -165,7 +169,8 @@ function LeadsPage() {
 
   const availableUsers = users.filter(user => {
     if (role === 'super_admin') return user.role === 'admin';
-    if (role === 'admin') return user.role === 'relationship_mgr';
+    if (role === 'admin')
+      return user.role === 'relationship_mgr' || user.role === 'financial_manager';
     return false;
   });
 
@@ -173,7 +178,7 @@ function LeadsPage() {
     <div className="container mx-auto px-4" onMouseUp={handleMouseUp}>
       <div className="flex justify-between items-center mb-6">
   <h1 className="text-2xl font-bold">All Leads</h1>
-  {(role === 'super_admin' || role === 'admin' || role === 'relationship_mgr') && (
+  {(role === 'super_admin' || role === 'admin' || role === 'relationship_mgr' || role === 'financial_manager') && (
     <div className="flex space-x-3">
       <button
         className="btn btn-primary flex items-center"
@@ -238,7 +243,11 @@ function LeadsPage() {
           >
             <option value="">Select</option>
             {users
-              .filter((user) => user.role === 'relationship_mgr' && user.team_id === selectedTeam)
+              .filter(
+                (user) =>
+                  (user.role === 'relationship_mgr' || user.role === 'financial_manager') &&
+                  user.team_id === selectedTeam
+              )
               .map((rm) => (
                 <option key={rm.id} value={rm.id}>
                   {rm.displayName}
@@ -329,7 +338,7 @@ function LeadsPage() {
                   </td>
                   <td className="p-3 truncate">{lead.fullName}</td>
                   <td className="p-3 truncate flex items-center gap-1">
-                    {role === 'relationship_mgr'
+                    {role === 'relationship_mgr' || role === 'financial_manager'
                       ? `${lead.phone.slice(0, 2)}******`
                       : lead.phone}
                     <button

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -68,6 +68,8 @@ function UsersPage() {
         return 'bg-green-500/20 text-green-400';
       case 'relationship_mgr':
         return 'bg-yellow-500/20 text-yellow-400';
+      case 'financial_manager':
+        return 'bg-yellow-500/20 text-yellow-400';
       default:
         return 'bg-gray-500/20 text-gray-400';
     }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,7 +1,13 @@
 import { create } from 'zustand';
 import axios from 'axios';
 
-type Role = 'super_admin' | 'admin' | 'team_leader' | 'relationship_mgr' | '';
+type Role =
+  | 'super_admin'
+  | 'admin'
+  | 'team_leader'
+  | 'relationship_mgr'
+  | 'financial_manager'
+  | '';
 
 interface AuthState {
   isAuthenticated: boolean;

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -8,7 +8,12 @@ export interface User {
   email: string;
   phoneNumber: string;
   password?: string;
-  role: 'super_admin' | 'admin' | 'team_leader' | 'relationship_mgr';
+  role:
+    | 'super_admin'
+    | 'admin'
+    | 'team_leader'
+    | 'relationship_mgr'
+    | 'financial_manager';
   status: 'Active' | 'Inactive';
   team_id?: string;
 }


### PR DESCRIPTION
## Summary
- add `financial_manager` role to auth and user stores
- allow selecting the new role in user modal
- enable financial manager access in sidebar and protected routes
- treat financial manager like relationship manager across pages
- update lead controller to handle financial manager

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68681705223c83288c22eaf1b2fdbcf1