### PR TITLE
Fix awaiting approval animation logic

### DIFF
--- a/src/components/modals/ClientDetailsModal.tsx
+++ b/src/components/modals/ClientDetailsModal.tsx
@@ -80,7 +80,13 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
   const addPaymentRow = () => {
     const now = new Date().toISOString();
     setPaymentHistory([
-      { amount: '', date: now, utr: '', approved: false },
+      {
+        amount: '',
+        date: now,
+        utr: '',
+        approved: true, // mark as approved until saved
+        isNew: true,
+      },
       ...paymentHistory,
     ]);
   };
@@ -88,7 +94,18 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const reversed = [...paymentHistory].reverse();
+    // Entries added locally should only trigger approval after saving.
+    // Remove empty new rows and mark new entries as not approved before sending.
+    const cleaned = paymentHistory
+      .filter((entry) => !(entry.isNew && entry.amount.trim() === ''))
+      .map((entry) => {
+        if (entry.isNew) {
+          return { ...entry, approved: false };
+        }
+        return entry;
+      });
+
+    const reversed = [...cleaned].reverse();
     const historyStr = serializePaymentHistory(reversed);
 
     await updateLead(lead.id, {

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -3,6 +3,11 @@ export interface PaymentEntry {
   date: string;
   utr: string;
   approved: boolean;
+  /**
+   * Indicates the payment row has been added locally and not yet saved.
+   * This flag is ignored when serializing and will not be sent to the server.
+   */
+  isNew?: boolean;
 }
 
 export function parsePaymentHistory(str?: string): PaymentEntry[] {


### PR DESCRIPTION
## Summary
- add optional `isNew` flag for payment entries
- keep new payment rows marked approved until saved
- update submit logic to convert new rows to pending approval

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686835cc30fc8328897c05fa510aea47