### PR TITLE
Lock down RM editing and redirect

### DIFF
--- a/src/components/modals/ClientDetailsModal.tsx
+++ b/src/components/modals/ClientDetailsModal.tsx
@@ -17,6 +17,7 @@ interface ClientDetailsModalProps {
 const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose, lead }) => {
   const { updateLead } = useLeadStore();
   const { role } = useAuthStore();
+  const isReadOnly = role === 'relationship_mgr';
   const [formData, setFormData] = useState({
     gender: '',
     dob: '',
@@ -127,7 +128,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label className="form-label">Gender</label>
-          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange}>
+          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange} disabled={isReadOnly}>
             <option value="">Select</option>
             <option value="Male">Male</option>
             <option value="Female">Female</option>
@@ -136,34 +137,36 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="form-group">
           <label className="form-label">Date of Birth</label>
-          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} />
+          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} disabled={isReadOnly} />
         </div>
         <div className="form-group">
           <label className="form-label">PAN Card Number</label>
-          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} />
+          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} disabled={isReadOnly} />
         </div>
         <div className="form-group">
           <label className="form-label">Aadhar Card Number</label>
-          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} />
+          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} disabled={isReadOnly} />
         </div>
         <div className="form-group">
           <label className="form-label">Notes</label>
-          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} />
+          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} disabled={isReadOnly} />
         </div>
         <div className="form-group">
           <label className="form-label">Won On</label>
-          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} />
+          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} disabled={isReadOnly} />
         </div>
         <div className="form-group">
           <div className="flex justify-between items-center mb-2">
             <label className="form-label">Payment History</label>
-            <button
-              type="button"
-              onClick={addPaymentRow}
-              className="text-sm px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 transition"
-            >
-              + Add Payment
-            </button>
+            {!isReadOnly && (
+              <button
+                type="button"
+                onClick={addPaymentRow}
+                className="text-sm px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 transition"
+              >
+                + Add Payment
+              </button>
+            )}
           </div>
           <table className="w-full text-sm text-left">
             <thead className="text-gray-400 border-b border-gray-600">
@@ -183,6 +186,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                       className="form-input"
                       value={entry.amount}
                       onChange={(e) => handlePaymentChange(i, 'amount', e.target.value)}
+                      disabled={isReadOnly}
                     />
                   </td>
                   <td className="p-2">
@@ -196,6 +200,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                           value={entry.utr}
                           onChange={(e) => handlePaymentChange(i, 'utr', e.target.value)}
                           onBlur={() => handlePaymentChange(i, 'approved', true)}
+                          disabled={isReadOnly}
                         />
                       )
                     ) : entry.approved ? (
@@ -214,7 +219,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="flex justify-end space-x-3 mt-6">
           <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>
-          <button type="submit" className="btn btn-primary">Save</button>
+          {!isReadOnly && <button type="submit" className="btn btn-primary">Save</button>}
         </div>
       </form>
     </Modal>

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -21,6 +21,8 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
   const { role, userId } = useAuthStore();
   const addToast = useToastStore((state) => state.addToast);
 
+  const isReadOnly = role === 'relationship_mgr' && !!lead;
+
   const [showConfirm, setShowConfirm] = useState(false);
 
   const [formData, setFormData] = useState<Omit<Lead, 'id'>>({
@@ -147,6 +149,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.fullName}
             onChange={handleChange}
             required
+            disabled={isReadOnly}
           />
         </div>
 
@@ -158,6 +161,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.phone}
             onChange={handleChange}
+            disabled={isReadOnly}
           />
         </div>
 
@@ -170,6 +174,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.email}
             onChange={handleChange}
             required
+            disabled={isReadOnly}
           />
         </div>
 
@@ -181,6 +186,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.altNumber}
             onChange={handleChange}
+            disabled={isReadOnly}
           />
         </div>
 
@@ -191,6 +197,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.deematAccountName}
             onChange={handleChange}
+            disabled={isReadOnly}
           >
             <option value="">Select</option>
             <option value="Zerodha">Zerodha</option>
@@ -206,6 +213,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.profession}
             onChange={handleChange}
+            disabled={isReadOnly}
           >
             <option value="">Select</option>
             <option value="Student">Student</option>
@@ -221,6 +229,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.stateName}
             onChange={handleChange}
+            disabled={isReadOnly}
           >
             <option value="">Select</option>
             <option value="Andhra Pradesh">Andhra Pradesh</option>
@@ -262,6 +271,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.capital}
             onChange={handleChange}
+            disabled={isReadOnly}
           />
         </div>
 
@@ -273,6 +283,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.segment}
             onChange={handleChange}
+            disabled={isReadOnly}
           />
         </div>
 
@@ -284,6 +295,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.notes}
             onChange={handleChange}
             rows={3}
+            disabled={isReadOnly}
           />
         </div>
 
@@ -294,6 +306,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.status}
             onChange={handleChange}
+            disabled={isReadOnly}
           >
             <option value="New">New</option>
             <option value="Contacted">Contacted</option>
@@ -312,9 +325,11 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
           >
             Cancel
           </button>
-          <button type="submit" className="btn btn-primary">
-            {lead ? 'Update Lead' : 'Add Lead'}
-          </button>
+          {!isReadOnly && (
+            <button type="submit" className="btn btn-primary">
+              {lead ? 'Update Lead' : 'Add Lead'}
+            </button>
+          )}
         </div>
       </form>
     </Modal>

--- a/src/pages/Clientpage.tsx
+++ b/src/pages/Clientpage.tsx
@@ -92,13 +92,15 @@ const ClientsPage = () => {
                       >
                         <Info size={16} />
                       </button>
-                      <button
-                        onClick={() => setEditLead(lead)}
-                        className="text-blue-400 hover:text-blue-300"
-                        title="Edit Client"
-                      >
-                        <Pencil size={16} />
-                      </button>
+                      {role !== 'relationship_mgr' && (
+                        <button
+                          onClick={() => setEditLead(lead)}
+                          className="text-blue-400 hover:text-blue-300"
+                          title="Edit Client"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                      )}
                     </td>
                   </tr>
                 );

--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -377,12 +377,14 @@ function LeadsPage() {
                     >
                       ℹ️
                     </button>
-                    <button
-                      onClick={() => handleEditLead(lead)}
-                      className="text-blue-400 hover:text-blue-300"
-                    >
-                      <Pencil size={16} />
-                    </button>
+                    {role !== 'relationship_mgr' && (
+                      <button
+                        onClick={() => handleEditLead(lead)}
+                        className="text-blue-400 hover:text-blue-300"
+                      >
+                        <Pencil size={16} />
+                      </button>
+                    )}
                     {(role === 'super_admin' || role === 'admin') && (
                       <button
                         onClick={() => handleDeleteLead(lead.id)}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -24,7 +24,12 @@ function LoginPage() {
     try {
       await login(email, password);
       addToast('Logged in successfully', 'success');
-      navigate('/');
+      const role = useAuthStore.getState().role;
+      if (role === 'relationship_mgr') {
+        navigate('/leads');
+      } else {
+        navigate('/');
+      }
     } catch (err: any) {
       // ✅ Safely access error message from backend
       const backendMessage =


### PR DESCRIPTION
## Summary
- redirect relationship managers to the leads page after login
- hide lead/client edit buttons for relationship managers
- disable fields in lead and client modals when edited by a relationship manager

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868ca1a546c8328ac5c217266ef52fa