### PR TITLE
Lock lead and client editing

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -116,8 +116,8 @@ const addLead = async (req, res) => {
     const safeAssignedTo = assignedTo && assignedTo.trim() !== '' ? assignedTo : null;
 
     const result = await pool.query(
-      `INSERT INTO leads (full_name, email, phone, alt_number, notes, deemat_account_name, profession, state_name, capital, segment, team_id, assigned_to)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      `INSERT INTO leads (full_name, email, phone, alt_number, notes, deemat_account_name, profession, state_name, capital, segment, team_id, assigned_to, rm_locked, client_locked)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
        RETURNING *`,
       [
         fullName,
@@ -131,7 +131,9 @@ const addLead = async (req, res) => {
         capital || '',
         segment || '',
         safeTeamId,
-        safeAssignedTo
+        safeAssignedTo,
+        false,
+        false
       ]
     );
     res.status(201).json(result.rows[0]);
@@ -143,6 +145,7 @@ const addLead = async (req, res) => {
 
 const updateLead = async (req, res) => {
   const { id } = req.params;
+  const { role, context } = req.query;
   const {
     fullName,
     email,
@@ -176,7 +179,27 @@ const updateLead = async (req, res) => {
   const safeDob = dob && dob.trim() !== '' ? dob : null;
   const safeAge = age && age !== '' ? age : null;
 
+  let rmLocked = false;
+  let clientLocked = false;
   try {
+    const lockRes = await pool.query('SELECT rm_locked, client_locked FROM leads WHERE id = $1', [id]);
+    rmLocked = lockRes.rows[0]?.rm_locked || false;
+    clientLocked = lockRes.rows[0]?.client_locked || false;
+
+    if (role === 'relationship_mgr') {
+      if (context === 'lead_edit') {
+        if (rmLocked) {
+          return res.status(403).json({ error: 'Lead details locked' });
+        }
+        rmLocked = true;
+      } else if (context === 'client_details') {
+        if (clientLocked) {
+          return res.status(403).json({ error: 'Client details locked' });
+        }
+        clientLocked = true;
+      }
+    }
+
     const result = await pool.query(
       `UPDATE leads
        SET full_name = $1,
@@ -197,8 +220,10 @@ const updateLead = async (req, res) => {
            payment_history = $16,
            status = $17,
            team_id = $18,
-           assigned_to = $19
-       WHERE id = $20 RETURNING *`,
+           assigned_to = $19,
+           rm_locked = $20,
+           client_locked = $21
+       WHERE id = $22 RETURNING *`,
       [
         fullName,
         email,
@@ -219,6 +244,8 @@ const updateLead = async (req, res) => {
         status,
         safeTeamId,
         safeAssignedTo,
+        rmLocked,
+        clientLocked,
         id
       ]
     );

--- a/src/components/modals/ClientDetailsModal.tsx
+++ b/src/components/modals/ClientDetailsModal.tsx
@@ -17,6 +17,7 @@ interface ClientDetailsModalProps {
 const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose, lead }) => {
   const { updateLead } = useLeadStore();
   const { role } = useAuthStore();
+  const locked = role === 'relationship_mgr' && lead.clientLocked;
   const [formData, setFormData] = useState({
     gender: '',
     dob: '',
@@ -93,6 +94,10 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (locked) {
+      onClose();
+      return;
+    }
 
     // Entries added locally should only trigger approval after saving.
     // Remove empty new rows and mark new entries as not approved before sending.
@@ -118,7 +123,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
       notes: formData.notes,
       wonOn: formData.wonOn,
       paymentHistory: historyStr
-    });
+    }, 'client_details');
     onClose();
   };
 
@@ -127,7 +132,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label className="form-label">Gender</label>
-          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange}>
+          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange} disabled={locked}>
             <option value="">Select</option>
             <option value="Male">Male</option>
             <option value="Female">Female</option>
@@ -136,23 +141,23 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="form-group">
           <label className="form-label">Date of Birth</label>
-          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} />
+          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} disabled={locked} />
         </div>
         <div className="form-group">
           <label className="form-label">PAN Card Number</label>
-          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} />
+          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} disabled={locked} />
         </div>
         <div className="form-group">
           <label className="form-label">Aadhar Card Number</label>
-          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} />
+          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} disabled={locked} />
         </div>
         <div className="form-group">
           <label className="form-label">Notes</label>
-          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} />
+          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} disabled={locked} />
         </div>
         <div className="form-group">
           <label className="form-label">Won On</label>
-          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} />
+          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} disabled={locked} />
         </div>
         <div className="form-group">
           <div className="flex justify-between items-center mb-2">
@@ -161,6 +166,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
               type="button"
               onClick={addPaymentRow}
               className="text-sm px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 transition"
+              disabled={locked}
             >
               + Add Payment
             </button>
@@ -183,6 +189,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                       className="form-input"
                       value={entry.amount}
                       onChange={(e) => handlePaymentChange(i, 'amount', e.target.value)}
+                      disabled={locked}
                     />
                   </td>
                   <td className="p-2">
@@ -196,6 +203,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                           value={entry.utr}
                           onChange={(e) => handlePaymentChange(i, 'utr', e.target.value)}
                           onBlur={() => handlePaymentChange(i, 'approved', true)}
+                          disabled={locked}
                         />
                       )
                     ) : entry.approved ? (
@@ -214,7 +222,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="flex justify-end space-x-3 mt-6">
           <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>
-          <button type="submit" className="btn btn-primary">Save</button>
+          <button type="submit" className="btn btn-primary" disabled={locked}>Save</button>
         </div>
       </form>
     </Modal>

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -20,6 +20,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
   const { users, fetchUsers } = useUserStore();
   const { role, userId } = useAuthStore();
   const addToast = useToastStore((state) => state.addToast);
+  const locked = role === 'relationship_mgr' && lead?.rmLocked;
 
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -89,6 +90,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
     ...formData,
     status: (forcedStatus ?? formData.status) as Lead['status'],
   };
+  let context = 'lead_edit';
 
   if (role === 'relationship_mgr') {
     const user = users.find(u => u.id === userId);
@@ -101,11 +103,16 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
     }
   }
 
+  if (locked && lead) {
+    finalData = { status: (forcedStatus ?? formData.status) as Lead['status'] } as any;
+    context = 'status_only';
+  }
+
   console.log("✅ submitLead triggered", formData);
   console.log("Final payload to update/add:", finalData);
 
   if (lead) {
-    await updateLead(lead.id, finalData);
+    await updateLead(lead.id, { ...lead, ...finalData }, context);
   } else {
     await addLead(finalData);
   }
@@ -147,6 +154,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.fullName}
             onChange={handleChange}
             required
+            disabled={locked}
           />
         </div>
 
@@ -158,6 +166,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.phone}
             onChange={handleChange}
+            disabled={locked}
           />
         </div>
 
@@ -170,6 +179,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.email}
             onChange={handleChange}
             required
+            disabled={locked}
           />
         </div>
 
@@ -181,6 +191,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.altNumber}
             onChange={handleChange}
+            disabled={locked}
           />
         </div>
 
@@ -191,6 +202,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.deematAccountName}
             onChange={handleChange}
+            disabled={locked}
           >
             <option value="">Select</option>
             <option value="Zerodha">Zerodha</option>
@@ -206,6 +218,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.profession}
             onChange={handleChange}
+            disabled={locked}
           >
             <option value="">Select</option>
             <option value="Student">Student</option>
@@ -221,6 +234,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.stateName}
             onChange={handleChange}
+            disabled={locked}
           >
             <option value="">Select</option>
             <option value="Andhra Pradesh">Andhra Pradesh</option>
@@ -262,6 +276,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.capital}
             onChange={handleChange}
+            disabled={locked}
           />
         </div>
 
@@ -273,6 +288,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.segment}
             onChange={handleChange}
+            disabled={locked}
           />
         </div>
 
@@ -284,6 +300,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.notes}
             onChange={handleChange}
             rows={3}
+            disabled={locked}
           />
         </div>
 
@@ -312,7 +329,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
           >
             Cancel
           </button>
-          <button type="submit" className="btn btn-primary">
+          <button type="submit" className="btn btn-primary" disabled={locked && !!lead}>
             {lead ? 'Update Lead' : 'Add Lead'}
           </button>
         </div>

--- a/src/components/modals/LeadProgressModal.tsx
+++ b/src/components/modals/LeadProgressModal.tsx
@@ -71,7 +71,7 @@ const LeadProgressModal: React.FC<LeadProgressModalProps> = ({ isOpen, onClose, 
       fullName,
       notes: updatedNotes,
       status: newStatus,
-    });
+    }, 'progress');
 
     onClose();
   };
@@ -86,7 +86,7 @@ const LeadProgressModal: React.FC<LeadProgressModalProps> = ({ isOpen, onClose, 
       fullName,
       notes: pendingUpdate.updatedNotes,
       status: pendingUpdate.newStatus,
-    });
+    }, 'progress');
     setShowConfirm(false);
     setPendingUpdate(null);
     onClose();

--- a/src/stores/leadStore.ts
+++ b/src/stores/leadStore.ts
@@ -22,6 +22,8 @@ export interface Lead {
   panCardNumber?: string;
   aadharCardNumber?: string;
   paymentHistory?: string;
+  rmLocked?: boolean;
+  clientLocked?: boolean;
   status: 'New' | 'Contacted' | 'Qualified' | 'Proposal' | 'Won' | 'Lost';
   team_id: string;
   assigned_to?: string;
@@ -32,7 +34,7 @@ interface LeadStore {
   loading: boolean;
   fetchLeads: () => Promise<void>;
   addLead: (lead: Omit<Lead, 'id'>) => Promise<void>;
-  updateLead: (id: string, lead: Omit<Lead, 'id'>) => Promise<void>;
+  updateLead: (id: string, lead: Omit<Lead, 'id'>, context?: string) => Promise<void>;
   deleteLead: (id: string) => Promise<void>;
   uploadLeads: (file: File) => Promise<void>;
 }
@@ -63,7 +65,9 @@ export const useLeadStore = create<LeadStore>((set) => ({
         age: lead.age,
         panCardNumber: lead.pan_card_number,
         aadharCardNumber: lead.aadhar_card_number,
-        paymentHistory: lead.payment_history
+        paymentHistory: lead.payment_history,
+        rmLocked: lead.rm_locked,
+        clientLocked: lead.client_locked
       }));
       set({ leads: mapped });
     } catch (err) {
@@ -85,10 +89,13 @@ export const useLeadStore = create<LeadStore>((set) => ({
     }
   },
 
-  updateLead: async (id, lead) => {
+  updateLead: async (id, lead, context) => {
     const addToast = useToastStore.getState().addToast;
     try {
-      await axios.put(`/api/leads/${id}`, lead);
+      const { role, userId } = useAuthStore.getState();
+      await axios.put(`/api/leads/${id}`, lead, {
+        params: { role, user_id: userId, context }
+      });
       await useLeadStore.getState().fetchLeads();
       addToast('Lead updated successfully', 'success');
     } catch (err) {


### PR DESCRIPTION
## Summary
- prevent relationship managers from editing lead fields after saving the first time
- block client detail edits once saved
- send user info when updating leads
- add server-side checks for locked records

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ccc9d57c83288ecdd5a22382136f