### PR TITLE
Restrict RM editing after first entry

### DIFF
--- a/src/components/modals/ClientDetailsModal.tsx
+++ b/src/components/modals/ClientDetailsModal.tsx
@@ -17,6 +17,7 @@ interface ClientDetailsModalProps {
 const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose, lead }) => {
   const { updateLead } = useLeadStore();
   const { role } = useAuthStore();
+  const [locked, setLocked] = useState(false);
   const [formData, setFormData] = useState({
     gender: '',
     dob: '',
@@ -30,6 +31,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
 
   useEffect(() => {
     if (lead) {
+      setLocked(localStorage.getItem(`client_locked_${lead.id}`) === 'true');
       const parseWon = () => {
         if (lead.wonOn) return lead.wonOn;
         if (!lead.notes) return '';
@@ -50,6 +52,8 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
 
       const history = parsePaymentHistory(lead.paymentHistory);
       setPaymentHistory(history.reverse()); // newest first
+    } else {
+      setLocked(false);
     }
   }, [lead]);
 
@@ -78,6 +82,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
   };
 
   const addPaymentRow = () => {
+    if (locked && role === 'relationship_mgr') return;
     const now = new Date().toISOString();
     setPaymentHistory([
       {
@@ -119,6 +124,10 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
       wonOn: formData.wonOn,
       paymentHistory: historyStr
     });
+    if (role === 'relationship_mgr') {
+      localStorage.setItem(`client_locked_${lead.id}`, 'true');
+      setLocked(true);
+    }
     onClose();
   };
 
@@ -127,7 +136,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label className="form-label">Gender</label>
-          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange}>
+          <select name="gender" className="form-input" value={formData.gender} onChange={handleChange} disabled={locked && role === 'relationship_mgr'}>
             <option value="">Select</option>
             <option value="Male">Male</option>
             <option value="Female">Female</option>
@@ -136,23 +145,23 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="form-group">
           <label className="form-label">Date of Birth</label>
-          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} />
+          <input type="date" name="dob" className="form-input" value={formData.dob} onChange={handleChange} disabled={locked && role === 'relationship_mgr'} />
         </div>
         <div className="form-group">
           <label className="form-label">PAN Card Number</label>
-          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} />
+          <input type="text" name="panCardNumber" className="form-input" value={formData.panCardNumber} onChange={handleChange} disabled={locked && role === 'relationship_mgr'} />
         </div>
         <div className="form-group">
           <label className="form-label">Aadhar Card Number</label>
-          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} />
+          <input type="text" name="aadharCardNumber" className="form-input" value={formData.aadharCardNumber} onChange={handleChange} disabled={locked && role === 'relationship_mgr'} />
         </div>
         <div className="form-group">
           <label className="form-label">Notes</label>
-          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} />
+          <textarea name="notes" className="form-input" rows={3} value={formData.notes} onChange={handleChange} disabled={locked && role === 'relationship_mgr'} />
         </div>
         <div className="form-group">
           <label className="form-label">Won On</label>
-          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} />
+          <input type="date" name="wonOn" className="form-input" value={formData.wonOn} onChange={handleChange} disabled={locked && role === 'relationship_mgr'} />
         </div>
         <div className="form-group">
           <div className="flex justify-between items-center mb-2">
@@ -161,6 +170,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
               type="button"
               onClick={addPaymentRow}
               className="text-sm px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 transition"
+              disabled={locked && role === 'relationship_mgr'}
             >
               + Add Payment
             </button>
@@ -183,6 +193,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                       className="form-input"
                       value={entry.amount}
                       onChange={(e) => handlePaymentChange(i, 'amount', e.target.value)}
+                      disabled={locked && role === 'relationship_mgr'}
                     />
                   </td>
                   <td className="p-2">
@@ -196,6 +207,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
                           value={entry.utr}
                           onChange={(e) => handlePaymentChange(i, 'utr', e.target.value)}
                           onBlur={() => handlePaymentChange(i, 'approved', true)}
+                          disabled={locked && role === 'relationship_mgr'}
                         />
                       )
                     ) : entry.approved ? (
@@ -214,7 +226,7 @@ const ClientDetailsModal: React.FC<ClientDetailsModalProps> = ({ isOpen, onClose
         </div>
         <div className="flex justify-end space-x-3 mt-6">
           <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>
-          <button type="submit" className="btn btn-primary">Save</button>
+          <button type="submit" className="btn btn-primary" disabled={locked && role === 'relationship_mgr'}>Save</button>
         </div>
       </form>
     </Modal>

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -22,6 +22,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
   const addToast = useToastStore((state) => state.addToast);
 
   const [showConfirm, setShowConfirm] = useState(false);
+  const [locked, setLocked] = useState(false);
 
   const [formData, setFormData] = useState<Omit<Lead, 'id'>>({
     fullName: '',
@@ -45,6 +46,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
 
   useEffect(() => {
     if (lead) {
+      setLocked(localStorage.getItem(`lead_locked_${lead.id}`) === 'true');
       setFormData({
         fullName: lead.fullName || '',
         phone: lead.phone || '',
@@ -60,6 +62,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
         team_id: lead.team_id || '',
       });
     } else {
+      setLocked(false);
       setFormData({
         fullName: '',
         phone: '',
@@ -106,6 +109,10 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
 
   if (lead) {
     await updateLead(lead.id, finalData);
+    if (role === 'relationship_mgr') {
+      localStorage.setItem(`lead_locked_${lead.id}`, 'true');
+      setLocked(true);
+    }
   } else {
     await addLead(finalData);
   }
@@ -181,6 +188,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.altNumber}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           />
         </div>
 
@@ -191,6 +199,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.deematAccountName}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           >
             <option value="">Select</option>
             <option value="Zerodha">Zerodha</option>
@@ -206,6 +215,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.profession}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           >
             <option value="">Select</option>
             <option value="Student">Student</option>
@@ -221,6 +231,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.stateName}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           >
             <option value="">Select</option>
             <option value="Andhra Pradesh">Andhra Pradesh</option>
@@ -262,6 +273,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.capital}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           />
         </div>
 
@@ -273,6 +285,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.segment}
             onChange={handleChange}
+            disabled={locked && role === 'relationship_mgr'}
           />
         </div>
 
@@ -284,6 +297,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.notes}
             onChange={handleChange}
             rows={3}
+            disabled={locked && role === 'relationship_mgr'}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- lock lead fields after a relationship manager saves once
- lock client detail form after a relationship manager saves once

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868e95d71808328bfd4b598ba755f2f