### PR TITLE
Limit lead field updates by RMs

### DIFF
--- a/Backend/controllers/leads.js
+++ b/Backend/controllers/leads.js
@@ -143,6 +143,7 @@ const addLead = async (req, res) => {
 
 const updateLead = async (req, res) => {
   const { id } = req.params;
+  const { role } = req.query;
   const {
     fullName,
     email,
@@ -177,6 +178,31 @@ const updateLead = async (req, res) => {
   const safeAge = age && age !== '' ? age : null;
 
   try {
+    if (role === 'relationship_mgr') {
+      const existingRes = await pool.query(
+        `SELECT email, alt_number, deemat_account_name, profession, state_name, capital, segment FROM leads WHERE id = $1`,
+        [id]
+      );
+      if (existingRes.rows.length === 0) {
+        return res.status(404).json({ error: 'Lead not found' });
+      }
+      const existing = existingRes.rows[0];
+      const checks = [
+        ['email', email, existing.email],
+        ['alt_number', altNumber, existing.alt_number],
+        ['deemat_account_name', deematAccountName, existing.deemat_account_name],
+        ['profession', profession, existing.profession],
+        ['state_name', stateName, existing.state_name],
+        ['capital', capital, existing.capital],
+        ['segment', segment, existing.segment],
+      ];
+      for (const [field, newVal, currentVal] of checks) {
+        if (currentVal && `${currentVal}`.trim() !== '' && newVal !== currentVal) {
+          return res.status(403).json({ error: `Field '${field}' cannot be edited once set` });
+        }
+      }
+    }
+
     const result = await pool.query(
       `UPDATE leads
        SET full_name = $1,

--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -170,6 +170,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.email}
             onChange={handleChange}
             required
+            disabled={role === 'relationship_mgr' && !!lead?.email}
           />
         </div>
 
@@ -181,6 +182,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.altNumber}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.altNumber}
           />
         </div>
 
@@ -191,6 +193,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.deematAccountName}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.deematAccountName}
           >
             <option value="">Select</option>
             <option value="Zerodha">Zerodha</option>
@@ -206,6 +209,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.profession}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.profession}
           >
             <option value="">Select</option>
             <option value="Student">Student</option>
@@ -221,6 +225,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.stateName}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.stateName}
           >
             <option value="">Select</option>
             <option value="Andhra Pradesh">Andhra Pradesh</option>
@@ -262,6 +267,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.capital}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.capital}
           />
         </div>
 
@@ -273,6 +279,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.segment}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.segment}
           />
         </div>
 

--- a/src/stores/leadStore.ts
+++ b/src/stores/leadStore.ts
@@ -88,7 +88,8 @@ export const useLeadStore = create<LeadStore>((set) => ({
   updateLead: async (id, lead) => {
     const addToast = useToastStore.getState().addToast;
     try {
-      await axios.put(`/api/leads/${id}`, lead);
+      const { role, userId } = useAuthStore.getState();
+      await axios.put(`/api/leads/${id}`, lead, { params: { role, user_id: userId } });
       await useLeadStore.getState().fetchLeads();
       addToast('Lead updated successfully', 'success');
     } catch (err) {


### PR DESCRIPTION
## Summary
- disallow relationship managers from editing certain lead details after they are initially set
- send current user role when updating leads
- disable lead form fields once they are filled for relationship managers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f5c327a48328b463637ffde0ee98