### PR TITLE
Limit lead field updates by RMs

### DIFF
--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -147,6 +147,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.fullName}
             onChange={handleChange}
             required
+            disabled={role === 'relationship_mgr' && !!lead}
           />
         </div>
 
@@ -158,6 +159,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.phone}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead}
           />
         </div>
 
@@ -170,6 +172,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.email}
             onChange={handleChange}
             required
+            disabled={role === 'relationship_mgr' && !!lead?.email}
           />
         </div>
 
@@ -181,6 +184,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.altNumber}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.altNumber}
           />
         </div>
 
@@ -191,6 +195,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.deematAccountName}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.deematAccountName}
           >
             <option value="">Select</option>
             <option value="Zerodha">Zerodha</option>
@@ -206,6 +211,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.profession}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.profession}
           >
             <option value="">Select</option>
             <option value="Student">Student</option>
@@ -221,6 +227,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.stateName}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.stateName}
           >
             <option value="">Select</option>
             <option value="Andhra Pradesh">Andhra Pradesh</option>
@@ -262,6 +269,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.capital}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.capital}
           />
         </div>
 
@@ -273,6 +281,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.segment}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.segment}
           />
         </div>
 

--- a/src/stores/leadStore.ts
+++ b/src/stores/leadStore.ts
@@ -88,7 +88,8 @@ export const useLeadStore = create<LeadStore>((set) => ({
   updateLead: async (id, lead) => {
     const addToast = useToastStore.getState().addToast;
     try {
-      await axios.put(`/api/leads/${id}`, lead);
+      const { role, userId } = useAuthStore.getState();
+      await axios.put(`/api/leads/${id}`, lead, { params: { role, user_id: userId } });
       await useLeadStore.getState().fetchLeads();
       addToast('Lead updated successfully', 'success');
     } catch (err) {


### PR DESCRIPTION
## Summary
- disallow relationship managers from editing certain lead details after they are initially set
- send current user role when updating leads
- disable lead form fields once they are filled for relationship managers
- lock full name and phone number for relationship managers when editing leads

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6868f5c327a48328b463637ffde0ee98