### PR TITLE
Fix lead modal editing for RMs

### DIFF
--- a/src/components/modals/LeadModal.tsx
+++ b/src/components/modals/LeadModal.tsx
@@ -147,6 +147,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             value={formData.fullName}
             onChange={handleChange}
             required
+            disabled={role === 'relationship_mgr' && !!lead?.fullName}
           />
         </div>
 
@@ -158,6 +159,7 @@ const LeadModal: React.FC<LeadModalProps> = ({ isOpen, onClose, lead }) => {
             className="form-input"
             value={formData.phone}
             onChange={handleChange}
+            disabled={role === 'relationship_mgr' && !!lead?.phone}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- restrict editing full name and phone fields when relationship managers update a lead

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868fcf941ac8328b7efebb7dd7e0a35